### PR TITLE
Fix `open_loop': redirection forbidden

### DIFF
--- a/lib/wordpress_tools/version.rb
+++ b/lib/wordpress_tools/version.rb
@@ -1,3 +1,3 @@
 module WordPressTools
-  VERSION = "1.1.2"
+  VERSION = "1.1.3"
 end

--- a/lib/wordpress_tools/wordpress.rb
+++ b/lib/wordpress_tools/wordpress.rb
@@ -32,7 +32,7 @@ module WordPressTools
       end
 
       def download_wordpress
-        download_url, version, locale = Net::HTTP.get('api.wordpress.org', "/core/version-check/1.5/?locale=#{options[:locale]}").split[2,3]
+        download_url, version, locale = URI.parse("https://api.wordpress.org/core/version-check/1.5/?locale=#{options[:locale]}").read.split[2,3]
 
         info("Downloading WordPress #{version} (#{locale})...")
         get(download_url, tempfile.path, force: true, verbose: false) || error("Could not download WordPress")

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,12 +27,12 @@ end
 FakeWeb.allow_net_connect = false
 WP_API_RESPONSE = <<-eof
     upgrade
-    http://wordpress.org/download/
-    http://wordpress.org/wordpress-3.6.zip
-    3.6
+    https://wordpress.org/download/
+    https://downloads.wordpress.org/release/wordpress-4.3.zip
+    4.3
     en_US
     5.2.4
     5.0
 eof
-FakeWeb.register_uri(:get, %r|http://api.wordpress.org/core/version-check/1.5/.*|, body: WP_API_RESPONSE)
-FakeWeb.register_uri(:get, "http://wordpress.org/wordpress-3.6.zip", body: File.expand_path('spec/fixtures/wordpress_stub.zip'))
+FakeWeb.register_uri(:get, %r|https://api.wordpress.org/core/version-check/1.5/.*|, body: WP_API_RESPONSE)
+FakeWeb.register_uri(:get, "https://downloads.wordpress.org/release/wordpress-4.3.zip", body: File.expand_path('spec/fixtures/wordpress_stub.zip'))


### PR DESCRIPTION
If you check the wordpress version in http instead of https, each url in the API response is without https (but there is a redirect in the download package)
